### PR TITLE
Add custom date header

### DIFF
--- a/util.go
+++ b/util.go
@@ -8,8 +8,12 @@ import (
 )
 
 func AddDateHeader(r *http.Request) {
+	AddCustomDateHeader(r, "Date")
+}
+
+func AddCustomDateHeader( r *http.Request, headerName string) {
 	datestr := time.Now().UTC().Format(time.RFC1123Z)
-	r.Header.Set("Date", datestr)
+	r.Header.Set(headerName, datestr)
 }
 
 func AddAuthorizationHeader(vg *Vangoh, r *http.Request, org string, key []byte, secret []byte) {

--- a/vangoh.go
+++ b/vangoh.go
@@ -355,7 +355,17 @@ func (vg *Vangoh) CreateSigningString(r *http.Request) string {
 	buffer.WriteString(r.Header.Get("Content-Type"))
 	buffer.WriteString(newline)
 
-	buffer.WriteString(r.Header.Get("Date"))
+	dateHeader := ""
+
+	if vg.customDateHeader != "" {
+		dateHeader = r.Header.Get(vg.customDateHeader)
+	}
+
+	if dateHeader == "" {
+		dateHeader = r.Header.Get("Date")
+	}
+
+	buffer.WriteString(dateHeader)
 	buffer.WriteString(newline)
 
 	customHeaders := vg.createHeadersString(r)

--- a/vangoh_test.go
+++ b/vangoh_test.go
@@ -645,10 +645,13 @@ func TestCustomDateFallback(t *testing.T) {
 	vg.SetAlgorithm(crypto.SHA1.New)
 	vg.SetCustomDateHeader("X-AWS-Date")
 
+	vg2 := NewSingleProvider(awsExampleProvider)
+	vg2.SetAlgorithm(crypto.SHA1.New)
+
 	req, _ := http.NewRequest("GET", "/johnsmith/photos/puppy.jpg", nil)
 
 	AddDateHeader(req)
-	AddAuthorizationHeader(vg, req, awsOrg, awsKey, awsSecret)
+	AddAuthorizationHeader(vg2, req, awsOrg, awsKey, awsSecret)
 
 	authErr := vg.AuthenticateRequest(req)
 

--- a/vangoh_test.go
+++ b/vangoh_test.go
@@ -3,7 +3,7 @@ package vangoh
 import (
 	"bytes"
 	"crypto"
-	_ "crypto/SHA1"
+	_ "crypto/sha1"
 	"errors"
 	"fmt"
 	"hash"
@@ -623,6 +623,50 @@ func TestDateMalformedFails(t *testing.T) {
 
 	authErr := vg.AuthenticateRequest(req)
 	assertError(t, authErr, ErrorDateHeaderMalformed)
+}
+
+func TestCustomDate(t *testing.T) {
+	vg := NewSingleProvider(awsExampleProvider)
+	vg.SetAlgorithm(crypto.SHA1.New)
+	vg.SetCustomDateHeader("X-AWS-Date")
+
+	req, _ := http.NewRequest("GET", "/johnsmith/photos/puppy.jpg", nil)
+
+	AddCustomDateHeader(req, "X-AWS-Date")
+	AddAuthorizationHeader(vg, req, awsOrg, awsKey, awsSecret)
+
+	authErr := vg.AuthenticateRequest(req)
+
+	assertNilError(t, authErr)
+}
+
+func TestCustomDateFallback(t *testing.T) {
+	vg := NewSingleProvider(awsExampleProvider)
+	vg.SetAlgorithm(crypto.SHA1.New)
+	vg.SetCustomDateHeader("X-AWS-Date")
+
+	req, _ := http.NewRequest("GET", "/johnsmith/photos/puppy.jpg", nil)
+
+	AddDateHeader(req)
+	AddAuthorizationHeader(vg, req, awsOrg, awsKey, awsSecret)
+
+	authErr := vg.AuthenticateRequest(req)
+
+	assertNilError(t, authErr)
+}
+
+func TestCustomDateMissingAllDates(t *testing.T) {
+	vg := NewSingleProvider(awsExampleProvider)
+	vg.SetAlgorithm(crypto.SHA1.New)
+	vg.SetCustomDateHeader("X-AWS-Date")
+
+	req, _ := http.NewRequest("GET", "/johnsmith/photos/puppy.jpg", nil)
+
+	AddAuthorizationHeader(vg, req, awsOrg, awsKey, awsSecret)
+
+	authErr := vg.AuthenticateRequest(req)
+
+	assertError(t, authErr, ErrorDateHeaderMissing)
 }
 
 func TestHandler(t *testing.T) {


### PR DESCRIPTION
Add ability to sign/verify with a custom date header.

This is useful when attempting to sign from a browser and do not have access to the Date header, or if trying to implement amazon v4 signature.
http://docs.aws.amazon.com/general/latest/gr/sigv4-date-handling.html

The logic is: If custom date header if set for Provider,  use it if it is included in request, otherwise fallback on "Date".