### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Vangoh [![GoDoc](https://godoc.org/github.com/auroratechnologies/vangoh?status.svg)](https://godoc.org/github.com/auroratechnologies/vangoh)
 ======
 
-######The Vanilla Go HMAC handler
+###### The Vanilla Go HMAC handler
 
 
 Vangoh implements the HMAC authentication scheme popularized by [Amazon's AWS](http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
